### PR TITLE
Add field merge context

### DIFF
--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -469,6 +469,27 @@ impl JoinSpecDefinition {
         })
     }
 
+    /// Create a `@join__field` directive application for the given subgraph.
+    pub(crate) fn field_directive(
+        &self,
+        schema: &FederationSchema,
+        subgraph_name: &Name,
+    ) -> Result<Directive, FederationError> {
+        let name_in_schema = self
+            .directive_name_in_schema(schema, &JOIN_FIELD_DIRECTIVE_NAME_IN_SPEC)?
+            .ok_or_else(|| SingleFederationError::Internal {
+                message: "Unexpectedly could not find join field directive in schema".to_owned(),
+            })?;
+
+        Ok(Directive {
+            name: name_in_schema,
+            arguments: vec![Node::new(Argument {
+                name: JOIN_GRAPH_ARGUMENT_NAME,
+                value: Node::new(Value::Enum(subgraph_name.clone())),
+            })],
+        })
+    }
+
     /// @join__graph
     fn graph_directive_specification(&self) -> DirectiveSpecification {
         DirectiveSpecification::new(

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -655,23 +655,12 @@ impl Merger {
                     &field.directives,
                 );
 
-            fields::merge_arguments(
-                field.arguments.iter(),
-                &mut supergraph_field.make_mut().arguments,
-                self,
-                directive_names,
-            );
-
-                self.add_join_field(
-                    &mut supergraph_field.make_mut().directives,
+                self.merge_field(
                     field,
+                    supergraph_field.make_mut(),
                     directive_names,
                     subgraph_name,
                 );
-
-                // TODO: replace this direct call with `merge_field` once that
-                // helper is ported. That will internally decide whether a
-                // `@join__field` directive is required.
             }
         } else if let ExtendedType::Interface(intf) = existing_type {
             self.interface_objects.insert(intf.name.clone());
@@ -721,23 +710,12 @@ impl Merger {
                     &field.directives,
                 );
 
-                fields::merge_arguments(
-                    field.arguments.iter(),
-                    &mut supergraph_field.make_mut().arguments,
-                    self,
-                    directive_names,
-                );
-
-                self.add_join_field(
-                    &mut supergraph_field.make_mut().directives,
+                self.merge_field(
                     field,
+                    supergraph_field.make_mut(),
                     directive_names,
                     subgraph_name,
                 );
-
-                // TODO: replace this direct call with `merge_field` once that
-                // helper is ported. That will internally decide whether a
-                // `@join__field` directive is required.
             }
         };
         // TODO merge fields
@@ -835,8 +813,7 @@ impl Merger {
             .get_all(&directive_names.r#override)
             .next()
             .and_then(|p| {
-                let overrides_from =
-                    directive_string_arg_value(p, &FEDERATION_FROM_ARGUMENT_NAME);
+                let overrides_from = directive_string_arg_value(p, &FEDERATION_FROM_ARGUMENT_NAME);
                 let overrides_label =
                     directive_string_arg_value(p, &FEDERATION_OVERRIDE_LABEL_ARGUMENT_NAME);
                 overrides_from.map(|from| (from, overrides_label))
@@ -858,6 +835,33 @@ impl Merger {
         );
 
         directives.push(Node::new(join_field_directive));
+    }
+
+    fn merge_field(
+        &mut self,
+        field: &FieldDefinition,
+        supergraph_field: &mut FieldDefinition,
+        directive_names: &DirectiveNames,
+        subgraph_name: &EnumValue,
+    ) {
+        self.merge_descriptions(&mut supergraph_field.description, &field.description);
+        self.add_inaccessible(
+            directive_names,
+            &mut supergraph_field.directives,
+            &field.directives,
+        );
+        fields::merge_arguments(
+            field.arguments.iter(),
+            &mut supergraph_field.arguments,
+            self,
+            directive_names,
+        );
+        self.add_join_field(
+            &mut supergraph_field.directives,
+            field,
+            directive_names,
+            subgraph_name,
+        );
     }
 
     // generic so it handles ast::DirectiveList and schema::DirectiveList

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -669,8 +669,9 @@ impl Merger {
                     subgraph_name,
                 );
 
-                // TODO: implement needsJoinField to avoid adding join__field when unnecessary
-                // https://github.com/apollographql/federation/blob/0d8a88585d901dff6844fdce1146a4539dec48df/composition-js/src/merging/merge.ts#L1648
+                // TODO: replace this direct call with `merge_field` once that
+                // helper is ported. That will internally decide whether a
+                // `@join__field` directive is required.
             }
         } else if let ExtendedType::Interface(intf) = existing_type {
             self.interface_objects.insert(intf.name.clone());
@@ -734,8 +735,9 @@ impl Merger {
                     subgraph_name,
                 );
 
-                // TODO: implement needsJoinField to avoid adding join__field when unnecessary
-                // https://github.com/apollographql/federation/blob/0d8a88585d901dff6844fdce1146a4539dec48df/composition-js/src/merging/merge.ts#L1648
+                // TODO: replace this direct call with `merge_field` once that
+                // helper is ported. That will internally decide whether a
+                // `@join__field` directive is required.
             }
         };
         // TODO merge fields

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -19,6 +19,7 @@ use apollo_compiler::ast::NamedType;
 use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::HashMap;
+use std::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::name;
@@ -61,6 +62,98 @@ use crate::link::spec_definition::SpecDefinition;
 use crate::schema::ValidFederationSchema;
 use crate::subgraph::ValidSubgraph;
 
+/// Trait for schema elements that expose a list of applied directive names.
+trait HasDirectives {
+    fn directive_names(&self) -> Vec<Name>;
+}
+
+impl<T: HasDirectives> HasDirectives for Node<T> {
+    fn directive_names(&self) -> Vec<Name> {
+        T::directive_names(self)
+    }
+}
+
+impl<T: HasDirectives + ?Sized> HasDirectives for Component<T> {
+    fn directive_names(&self) -> Vec<Name> {
+        T::directive_names(&**self)
+    }
+}
+
+impl<T: HasDirectives> HasDirectives for Option<T> {
+    fn directive_names(&self) -> Vec<Name> {
+        match self {
+            Some(v) => v.directive_names(),
+            None => Vec::new(),
+        }
+    }
+}
+
+impl<T: HasDirectives + ?Sized> HasDirectives for &T {
+    fn directive_names(&self) -> Vec<Name> {
+        (*self).directive_names()
+    }
+}
+
+impl HasDirectives for FieldDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for EnumValueDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::InputValueDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::ObjectType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::InterfaceType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::UnionType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::EnumType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::InputObjectType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::ScalarType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::SchemaDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.iter().map(|d| d.name.clone()).collect()
+    }
+}
+
 type MergeWarning = String;
 type MergeError = String;
 
@@ -70,6 +163,7 @@ struct Merger {
     needs_inaccessible: bool,
     interface_objects: IndexSet<Name>,
     description_sources: HashMap<String, String>,
+    applied_directives_to_merge: Vec<HashSet<Name>>,
 }
 
 pub struct MergeSuccess {
@@ -134,6 +228,7 @@ impl Merger {
             needs_inaccessible: false,
             interface_objects: IndexSet::default(),
             description_sources: HashMap::default(),
+            applied_directives_to_merge: Vec::new(),
         }
     }
 
@@ -946,6 +1041,30 @@ impl Merger {
                 .into(),
             );
         }
+    }
+
+    fn gather_applied_directive_names<T>(&self, sources: &[Option<&T>]) -> HashSet<Name>
+    where
+        T: HasDirectives,
+    {
+        let mut names = HashSet::new();
+        for source in sources {
+            if let Some(value) = source {
+                for name in value.directive_names() {
+                    names.insert(name);
+                }
+            }
+        }
+        names
+    }
+
+    fn record_applied_directives_to_merge<T: HasDirectives + Clone>(
+        &mut self,
+        sources: &[Option<&T>],
+        _dest: &mut T,
+    ) {
+        let names = self.gather_applied_directive_names(sources);
+        self.applied_directives_to_merge.push(names);
     }
 }
 

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -69,6 +69,7 @@ struct Merger {
     composition_hints: Vec<MergeWarning>,
     needs_inaccessible: bool,
     interface_objects: IndexSet<Name>,
+    description_sources: HashMap<String, String>,
 }
 
 pub struct MergeSuccess {
@@ -132,6 +133,7 @@ impl Merger {
             errors: Vec::new(),
             needs_inaccessible: false,
             interface_objects: IndexSet::default(),
+            description_sources: HashMap::default(),
         }
     }
 
@@ -325,15 +327,33 @@ impl Merger {
         Ok(())
     }
 
-    fn merge_descriptions<T: Eq + Clone>(&mut self, merged: &mut Option<T>, new: &Option<T>) {
+    fn merge_descriptions<T: Eq + Clone>(
+        &mut self,
+        element: &str,
+        subgraph_name: &str,
+        merged: &mut Option<T>,
+        new: &Option<T>,
+    ) {
         match (&mut *merged, new) {
             (_, None) => {}
-            (None, Some(_)) => merged.clone_from(new),
+            (None, Some(_)) => {
+                merged.clone_from(new);
+                self.description_sources
+                    .insert(element.to_string(), subgraph_name.to_string());
+            }
             (Some(a), Some(b)) => {
                 if a != b {
-                    // TODO add info about type and from/to subgraph
-                    self.composition_hints
-                        .push(String::from("conflicting descriptions"));
+                    let first = self
+                        .description_sources
+                        .get(element)
+                        .cloned()
+                        .unwrap_or_else(|| "another subgraph".to_string());
+                    self.composition_hints.push(format!(
+                        "conflicting descriptions for {element} between subgraphs {first} and {subgraph}",
+                        element = element,
+                        first = first,
+                        subgraph = subgraph_name
+                    ));
                 }
             }
         }
@@ -342,7 +362,12 @@ impl Merger {
     fn merge_schema(&mut self, supergraph_schema: &mut Schema, subgraph: &ValidFederationSubgraph) {
         let supergraph_def = &mut supergraph_schema.schema_definition.make_mut();
         let subgraph_def = &subgraph.schema.schema().schema_definition;
-        self.merge_descriptions(&mut supergraph_def.description, &subgraph_def.description);
+        self.merge_descriptions(
+            "schema",
+            &subgraph.name,
+            &mut supergraph_def.description,
+            &subgraph_def.description,
+        );
 
         if subgraph_def.query.is_some() {
             supergraph_def.query.clone_from(&subgraph_def.query);
@@ -370,7 +395,7 @@ impl Merger {
     ) {
         let existing_type = types
             .entry(enum_name.clone())
-            .or_insert(copy_enum_type(enum_name, enum_type));
+            .or_insert(copy_enum_type(enum_name.clone(), enum_type));
 
         if let ExtendedType::Enum(e) = existing_type {
             let join_type_directives =
@@ -383,7 +408,12 @@ impl Merger {
                 &enum_type.directives,
             );
 
-            self.merge_descriptions(&mut e.make_mut().description, &enum_type.description);
+            self.merge_descriptions(
+                &format!("enum {}", enum_name),
+                &subgraph_name.to_name().to_string(),
+                &mut e.make_mut().description,
+                &enum_type.description,
+            );
 
             // TODO we need to merge those fields LAST so we know whether enum is used as input/output/both as different merge rules will apply
             // below logic only works for output enums
@@ -397,7 +427,12 @@ impl Merger {
                         description: None,
                         directives: Default::default(),
                     }));
-                self.merge_descriptions(&mut ev.make_mut().description, &enum_value.description);
+                self.merge_descriptions(
+                    &format!("enum value {}.{}", enum_name, enum_value_name),
+                    &subgraph_name.to_name().to_string(),
+                    &mut ev.make_mut().description,
+                    &enum_value.description,
+                );
 
                 self.add_inaccessible(
                     metadata,
@@ -499,7 +534,7 @@ impl Merger {
     ) {
         let existing_type = types
             .entry(interface_name.clone())
-            .or_insert(copy_interface_type(interface_name, interface));
+            .or_insert(copy_interface_type(interface_name.clone(), interface));
 
         if let ExtendedType::Interface(intf) = existing_type {
             let key_directives = interface.directives.get_all(&directive_names.key);
@@ -554,6 +589,8 @@ impl Merger {
                     directive_names,
                 );
                 self.merge_descriptions(
+                    &format!("field {}.{}", interface_name, field_name),
+                    &subgraph_name.to_name().to_string(),
                     &mut supergraph_field.make_mut().description,
                     &field.description,
                 );
@@ -595,7 +632,7 @@ impl Merger {
         let existing_type = types
             .entry(object_name.clone())
             .or_insert(copy_object_type_stub(
-                object_name,
+                object_name.clone(),
                 object,
                 is_interface_object,
             ));
@@ -606,7 +643,12 @@ impl Merger {
                 join_type_applied_directive(subgraph_name.clone(), key_directives, false);
             let mutable_object = obj.make_mut();
             mutable_object.directives.extend(join_type_directives);
-            self.merge_descriptions(&mut mutable_object.description, &object.description);
+            self.merge_descriptions(
+                &format!("type {}", object_name),
+                &subgraph_name.to_name().to_string(),
+                &mut mutable_object.description,
+                &object.description,
+            );
             self.add_inaccessible(
                 directive_names,
                 &mut mutable_object.directives,
@@ -645,6 +687,8 @@ impl Merger {
                     })),
                 };
                 self.merge_descriptions(
+                    &format!("field {}.{}", object_name, field_name),
+                    &subgraph_name.to_name().to_string(),
                     &mut supergraph_field.make_mut().description,
                     &field.description,
                 );
@@ -670,7 +714,12 @@ impl Merger {
                 join_type_applied_directive(subgraph_name.clone(), key_directives, true);
             let mutable_object = intf.make_mut();
             mutable_object.directives.extend(join_type_directives);
-            self.merge_descriptions(&mut mutable_object.description, &object.description);
+            self.merge_descriptions(
+                &format!("type {}", object_name),
+                &subgraph_name.to_name().to_string(),
+                &mut mutable_object.description,
+                &object.description,
+            );
             self.add_inaccessible(
                 directive_names,
                 &mut mutable_object.directives,
@@ -700,6 +749,8 @@ impl Merger {
                     })),
                 };
                 self.merge_descriptions(
+                    &format!("field {}.{}", object_name, field_name),
+                    &subgraph_name.to_name().to_string(),
                     &mut supergraph_field.make_mut().description,
                     &field.description,
                 );
@@ -844,7 +895,12 @@ impl Merger {
         directive_names: &DirectiveNames,
         subgraph_name: &EnumValue,
     ) {
-        self.merge_descriptions(&mut supergraph_field.description, &field.description);
+        self.merge_descriptions(
+            "field",
+            &subgraph_name.to_name().to_string(),
+            &mut supergraph_field.description,
+            &field.description,
+        );
         self.add_inaccessible(
             directive_names,
             &mut supergraph_field.directives,

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -655,56 +655,19 @@ impl Merger {
                     &field.directives,
                 );
 
-                fields::merge_arguments(
-                    field.arguments.iter(),
-                    &mut supergraph_field.make_mut().arguments,
-                    self,
+            fields::merge_arguments(
+                field.arguments.iter(),
+                &mut supergraph_field.make_mut().arguments,
+                self,
+                directive_names,
+            );
+
+                self.add_join_field(
+                    &mut supergraph_field.make_mut().directives,
+                    field,
                     directive_names,
-                );
-
-                let requires_directive_option = field
-                    .directives
-                    .get_all(&directive_names.requires)
-                    .next()
-                    .and_then(|p| directive_string_arg_value(p, &FEDERATION_FIELDS_ARGUMENT_NAME));
-
-                let provides_directive_option = field
-                    .directives
-                    .get_all(&directive_names.provides)
-                    .next()
-                    .and_then(|p| directive_string_arg_value(p, &FEDERATION_FIELDS_ARGUMENT_NAME));
-
-                let overrides_directive_option = field
-                    .directives
-                    .get_all(&directive_names.r#override)
-                    .next()
-                    .and_then(|p| {
-                        let overrides_from =
-                            directive_string_arg_value(p, &FEDERATION_FROM_ARGUMENT_NAME);
-                        let overrides_label =
-                            directive_string_arg_value(p, &FEDERATION_OVERRIDE_LABEL_ARGUMENT_NAME);
-                        overrides_from.map(|from| (from, overrides_label))
-                    });
-
-                let external_field = field
-                    .directives
-                    .get_all(&directive_names.external)
-                    .next()
-                    .is_some();
-
-                let join_field_directive = join_field_applied_directive(
                     subgraph_name,
-                    requires_directive_option,
-                    provides_directive_option,
-                    external_field,
-                    overrides_directive_option,
-                    Some(&field.ty),
                 );
-
-                supergraph_field
-                    .make_mut()
-                    .directives
-                    .push(Node::new(join_field_directive));
 
                 // TODO: implement needsJoinField to avoid adding join__field when unnecessary
                 // https://github.com/apollographql/federation/blob/0d8a88585d901dff6844fdce1146a4539dec48df/composition-js/src/merging/merge.ts#L1648
@@ -763,49 +726,13 @@ impl Merger {
                     self,
                     directive_names,
                 );
-                let requires_directive_option = field
-                    .directives
-                    .get_all(&directive_names.requires)
-                    .next()
-                    .and_then(|p| directive_string_arg_value(p, &FEDERATION_FIELDS_ARGUMENT_NAME));
 
-                let provides_directive_option = field
-                    .directives
-                    .get_all(&directive_names.provides)
-                    .next()
-                    .and_then(|p| directive_string_arg_value(p, &FEDERATION_FIELDS_ARGUMENT_NAME));
-
-                let overrides_directive_option = field
-                    .directives
-                    .get_all(&directive_names.r#override)
-                    .next()
-                    .and_then(|p| {
-                        let overrides_from =
-                            directive_string_arg_value(p, &FEDERATION_FROM_ARGUMENT_NAME);
-                        let overrides_label =
-                            directive_string_arg_value(p, &FEDERATION_OVERRIDE_LABEL_ARGUMENT_NAME);
-                        overrides_from.map(|from| (from, overrides_label))
-                    });
-
-                let external_field = field
-                    .directives
-                    .get_all(&directive_names.external)
-                    .next()
-                    .is_some();
-
-                let join_field_directive = join_field_applied_directive(
+                self.add_join_field(
+                    &mut supergraph_field.make_mut().directives,
+                    field,
+                    directive_names,
                     subgraph_name,
-                    requires_directive_option,
-                    provides_directive_option,
-                    external_field,
-                    overrides_directive_option,
-                    Some(&field.ty),
                 );
-
-                supergraph_field
-                    .make_mut()
-                    .directives
-                    .push(Node::new(join_field_directive));
 
                 // TODO: implement needsJoinField to avoid adding join__field when unnecessary
                 // https://github.com/apollographql/federation/blob/0d8a88585d901dff6844fdce1146a4539dec48df/composition-js/src/merging/merge.ts#L1648
@@ -880,6 +807,55 @@ impl Merger {
         } else {
             // conflict?
         }
+    }
+
+    fn add_join_field(
+        &self,
+        directives: &mut Vec<Node<Directive>>,
+        field: &FieldDefinition,
+        directive_names: &DirectiveNames,
+        subgraph_name: &EnumValue,
+    ) {
+        let requires_directive_option = field
+            .directives
+            .get_all(&directive_names.requires)
+            .next()
+            .and_then(|p| directive_string_arg_value(p, &FEDERATION_FIELDS_ARGUMENT_NAME));
+
+        let provides_directive_option = field
+            .directives
+            .get_all(&directive_names.provides)
+            .next()
+            .and_then(|p| directive_string_arg_value(p, &FEDERATION_FIELDS_ARGUMENT_NAME));
+
+        let overrides_directive_option = field
+            .directives
+            .get_all(&directive_names.r#override)
+            .next()
+            .and_then(|p| {
+                let overrides_from =
+                    directive_string_arg_value(p, &FEDERATION_FROM_ARGUMENT_NAME);
+                let overrides_label =
+                    directive_string_arg_value(p, &FEDERATION_OVERRIDE_LABEL_ARGUMENT_NAME);
+                overrides_from.map(|from| (from, overrides_label))
+            });
+
+        let external_field = field
+            .directives
+            .get_all(&directive_names.external)
+            .next()
+            .is_some();
+
+        let join_field_directive = join_field_applied_directive(
+            subgraph_name,
+            requires_directive_option,
+            provides_directive_option,
+            external_field,
+            overrides_directive_option,
+            Some(&field.ty),
+        );
+
+        directives.push(Node::new(join_field_directive));
     }
 
     // generic so it handles ast::DirectiveList and schema::DirectiveList

--- a/apollo-federation/src/merger/field_merge_context.rs
+++ b/apollo-federation/src/merger/field_merge_context.rs
@@ -33,7 +33,10 @@ impl FieldMergeContext {
     }
 
     pub(crate) fn is_used_overridden(&self, idx: usize) -> bool {
-        self.props.get(&idx).map(|p| p.used_overridden).unwrap_or(false)
+        self.props
+            .get(&idx)
+            .map(|p| p.used_overridden)
+            .unwrap_or(false)
     }
 
     pub(crate) fn is_unused_overridden(&self, idx: usize) -> bool {
@@ -51,7 +54,9 @@ impl FieldMergeContext {
     }
 
     pub(crate) fn override_label(&self, idx: usize) -> Option<&str> {
-        self.props.get(&idx).and_then(|p| p.override_label.as_deref())
+        self.props
+            .get(&idx)
+            .and_then(|p| p.override_label.as_deref())
     }
 
     pub(crate) fn set_used_overridden(&mut self, idx: usize) {
@@ -82,9 +87,7 @@ impl FieldMergeContext {
     where
         F: FnMut(&FieldMergeContextProperties, usize) -> bool,
     {
-        self.props
-            .iter()
-            .any(|(&idx, props)| predicate(props, idx))
+        self.props.iter().any(|(&idx, props)| predicate(props, idx))
     }
 }
 
@@ -119,4 +122,3 @@ mod tests {
         assert!(ctx.some(|p, idx| idx == 0 && p.used_overridden));
     }
 }
-

--- a/apollo-federation/src/merger/field_merge_context.rs
+++ b/apollo-federation/src/merger/field_merge_context.rs
@@ -5,8 +5,6 @@ use crate::merger::merge::Sources;
 #[derive(Debug, Default, Clone)]
 pub(crate) struct FieldMergeContextProperties {
     pub(crate) used_overridden: bool,
-    pub(crate) unused_overridden: bool,
-    pub(crate) override_with_unknown_target: bool,
     pub(crate) override_label: Option<String>,
 }
 
@@ -23,8 +21,6 @@ impl FieldMergeContext {
                 i,
                 FieldMergeContextProperties {
                     used_overridden: false,
-                    unused_overridden: false,
-                    override_with_unknown_target: false,
                     override_label: None,
                 },
             );
@@ -39,44 +35,20 @@ impl FieldMergeContext {
             .unwrap_or(false)
     }
 
-    pub(crate) fn is_unused_overridden(&self, idx: usize) -> bool {
-        self.props
-            .get(&idx)
-            .map(|p| p.unused_overridden)
-            .unwrap_or(false)
-    }
-
-    pub(crate) fn has_override_with_unknown_target(&self, idx: usize) -> bool {
-        self.props
-            .get(&idx)
-            .map(|p| p.override_with_unknown_target)
-            .unwrap_or(false)
-    }
-
     pub(crate) fn override_label(&self, idx: usize) -> Option<&str> {
         self.props
             .get(&idx)
             .and_then(|p| p.override_label.as_deref())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn set_used_overridden(&mut self, idx: usize) {
         if let Some(p) = self.props.get_mut(&idx) {
             p.used_overridden = true;
         }
     }
 
-    pub(crate) fn set_unused_overridden(&mut self, idx: usize) {
-        if let Some(p) = self.props.get_mut(&idx) {
-            p.unused_overridden = true;
-        }
-    }
-
-    pub(crate) fn set_override_with_unknown_target(&mut self, idx: usize) {
-        if let Some(p) = self.props.get_mut(&idx) {
-            p.override_with_unknown_target = true;
-        }
-    }
-
+    #[allow(dead_code)]
     pub(crate) fn set_override_label(&mut self, idx: usize, label: String) {
         if let Some(p) = self.props.get_mut(&idx) {
             p.override_label = Some(label);
@@ -103,19 +75,14 @@ mod tests {
         let mut ctx = FieldMergeContext::new(&sources);
         // Defaults
         assert!(!ctx.is_used_overridden(0));
-        assert!(!ctx.is_unused_overridden(1));
         assert!(ctx.override_label(1).is_none());
 
         // Update properties
         ctx.set_used_overridden(0);
-        ctx.set_unused_overridden(1);
-        ctx.set_override_with_unknown_target(1);
         ctx.set_override_label(1, "label".to_string());
 
         // Verify getters
         assert!(ctx.is_used_overridden(0));
-        assert!(ctx.is_unused_overridden(1));
-        assert!(ctx.has_override_with_unknown_target(1));
         assert_eq!(ctx.override_label(1), Some("label"));
 
         // Predicate query

--- a/apollo-federation/src/merger/field_merge_context.rs
+++ b/apollo-federation/src/merger/field_merge_context.rs
@@ -88,3 +88,35 @@ impl FieldMergeContext {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_merge_context_properties() {
+        // Set up sources for 2 subgraphs
+        let sources: Sources<()> = [(0, Some(())), (1, None)].into_iter().collect();
+
+        let mut ctx = FieldMergeContext::new(&sources);
+        // Defaults
+        assert!(!ctx.is_used_overridden(0));
+        assert!(!ctx.is_unused_overridden(1));
+        assert!(ctx.override_label(1).is_none());
+
+        // Update properties
+        ctx.set_used_overridden(0);
+        ctx.set_unused_overridden(1);
+        ctx.set_override_with_unknown_target(1);
+        ctx.set_override_label(1, "label".to_string());
+
+        // Verify getters
+        assert!(ctx.is_used_overridden(0));
+        assert!(ctx.is_unused_overridden(1));
+        assert!(ctx.has_override_with_unknown_target(1));
+        assert_eq!(ctx.override_label(1), Some("label"));
+
+        // Predicate query
+        assert!(ctx.some(|p, idx| idx == 0 && p.used_overridden));
+    }
+}
+

--- a/apollo-federation/src/merger/field_merge_context.rs
+++ b/apollo-federation/src/merger/field_merge_context.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use crate::merger::merge::Sources;
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct FieldMergeContextProperties {
+    pub(crate) used_overridden: bool,
+    pub(crate) unused_overridden: bool,
+    pub(crate) override_with_unknown_target: bool,
+    pub(crate) override_label: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct FieldMergeContext {
+    props: HashMap<usize, FieldMergeContextProperties>,
+}
+
+impl FieldMergeContext {
+    pub(crate) fn new<T>(sources: &Sources<T>) -> Self {
+        let mut props = HashMap::new();
+        for (&i, _) in sources.iter() {
+            props.insert(
+                i,
+                FieldMergeContextProperties {
+                    used_overridden: false,
+                    unused_overridden: false,
+                    override_with_unknown_target: false,
+                    override_label: None,
+                },
+            );
+        }
+        Self { props }
+    }
+
+    pub(crate) fn is_used_overridden(&self, idx: usize) -> bool {
+        self.props.get(&idx).map(|p| p.used_overridden).unwrap_or(false)
+    }
+
+    pub(crate) fn is_unused_overridden(&self, idx: usize) -> bool {
+        self.props
+            .get(&idx)
+            .map(|p| p.unused_overridden)
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn has_override_with_unknown_target(&self, idx: usize) -> bool {
+        self.props
+            .get(&idx)
+            .map(|p| p.override_with_unknown_target)
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn override_label(&self, idx: usize) -> Option<&str> {
+        self.props.get(&idx).and_then(|p| p.override_label.as_deref())
+    }
+
+    pub(crate) fn set_used_overridden(&mut self, idx: usize) {
+        if let Some(p) = self.props.get_mut(&idx) {
+            p.used_overridden = true;
+        }
+    }
+
+    pub(crate) fn set_unused_overridden(&mut self, idx: usize) {
+        if let Some(p) = self.props.get_mut(&idx) {
+            p.unused_overridden = true;
+        }
+    }
+
+    pub(crate) fn set_override_with_unknown_target(&mut self, idx: usize) {
+        if let Some(p) = self.props.get_mut(&idx) {
+            p.override_with_unknown_target = true;
+        }
+    }
+
+    pub(crate) fn set_override_label(&mut self, idx: usize, label: String) {
+        if let Some(p) = self.props.get_mut(&idx) {
+            p.override_label = Some(label);
+        }
+    }
+
+    pub(crate) fn some<F>(&self, mut predicate: F) -> bool
+    where
+        F: FnMut(&FieldMergeContextProperties, usize) -> bool,
+    {
+        self.props
+            .iter()
+            .any(|(&idx, props)| predicate(props, idx))
+    }
+}
+

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -355,6 +355,7 @@ pub(crate) mod tests {
             join_spec_definition,
             join_directive_identities: Default::default(),
             schema_to_import_to_feature_url: Default::default(),
+            applied_directives_to_merge: Vec::new(),
         })
     }
 

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -609,9 +609,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_join_field() {
-        use apollo_compiler::schema::{FieldDefinition, ObjectType, Type};
-        use crate::schema::position::ObjectTypeDefinitionPosition;
         use crate::schema::position::ObjectFieldDefinitionPosition;
+        use crate::schema::position::ObjectTypeDefinitionPosition;
+        use apollo_compiler::schema::{FieldDefinition, ObjectType, Type};
 
         let mut merger = create_test_merger().expect("valid Merger object");
 
@@ -663,10 +663,8 @@ pub(crate) mod tests {
             .add_join_field(&sources, &field_pos.clone().into())
             .expect("directive added");
 
-        let directives = field_pos.get_applied_directives(
-            &merger.merged,
-            &Name::new("join__field").expect("name"),
-        );
+        let directives = field_pos
+            .get_applied_directives(&merger.merged, &Name::new("join__field").expect("name"));
         assert_eq!(directives.len(), 2);
     }
 }

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -303,6 +303,8 @@ pub(crate) mod tests {
 
             directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
+            directive @join__field(graph: join__Graph) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
             enum join__Graph {
                 A @join__graph(name: "A", url: "http://localhost:4002/")
                 B @join__graph(name: "B", url: "http://localhost:4003/")
@@ -603,5 +605,68 @@ pub(crate) mod tests {
         assert!(enum_vals.contains(&"INACTIVE".to_string()));
         assert!(enum_vals.contains(&"PENDING".to_string()));
         // Should not generate any errors or hints
+    }
+
+    #[test]
+    fn test_add_join_field() {
+        use apollo_compiler::schema::{FieldDefinition, ObjectType, Type};
+        use crate::schema::position::ObjectTypeDefinitionPosition;
+        use crate::schema::position::ObjectFieldDefinitionPosition;
+
+        let mut merger = create_test_merger().expect("valid Merger object");
+
+        let obj_pos = ObjectTypeDefinitionPosition {
+            type_name: Name::new("User").expect("name"),
+        };
+        let obj = Node::new(ObjectType {
+            description: None,
+            name: Name::new("User").expect("name"),
+            directives: Default::default(),
+            fields: Default::default(),
+            implements_interfaces: Default::default(),
+        });
+        obj_pos.pre_insert(&mut merger.merged).unwrap();
+        obj_pos.insert(&mut merger.merged, obj).unwrap();
+
+        let field_pos = ObjectFieldDefinitionPosition {
+            type_name: Name::new("User").expect("name"),
+            field_name: Name::new("name").expect("name"),
+        };
+        let field = Component::new(FieldDefinition {
+            description: None,
+            name: Name::new("name").expect("name"),
+            arguments: vec![],
+            ty: Type::Named(Name::new("String").expect("name")),
+            directives: Default::default(),
+        });
+        field_pos.insert(&mut merger.merged, field).unwrap();
+
+        let src_field = Node::new(FieldDefinition {
+            description: None,
+            name: Name::new("name").expect("name"),
+            arguments: vec![],
+            ty: Type::Named(Name::new("String").expect("name")),
+            directives: Default::default(),
+        });
+
+        let sources: Sources<Node<FieldDefinition>> =
+            [(0, Some(src_field.clone())), (1, Some(src_field))]
+                .into_iter()
+                .collect();
+
+        merger
+            .fields_with_from_context
+            .object_fields
+            .insert(field_pos.clone());
+
+        merger
+            .add_join_field(&sources, &field_pos.clone().into())
+            .expect("directive added");
+
+        let directives = field_pos.get_applied_directives(
+            &merger.merged,
+            &Name::new("join__field").expect("name"),
+        );
+        assert_eq!(directives.len(), 2);
     }
 }

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -660,7 +660,7 @@ pub(crate) mod tests {
             .insert(field_pos.clone());
 
         merger
-            .add_join_field(&sources, &field_pos.clone().into())
+            .merge_object_field(sources, &field_pos)
             .expect("directive added");
 
         let directives = field_pos

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -21,6 +21,14 @@ use crate::error::FederationError;
 use crate::internal_error;
 use crate::link::federation_spec_definition::FEDERATION_OPERATION_TYPES;
 use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
+use crate::link::join_spec_definition::JOIN_CONTEXTARGUMENTS_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_EXTERNAL_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_OVERRIDE_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_OVERRIDE_LABEL_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_PROVIDES_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_REQUIRES_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_TYPE_ARGUMENT_NAME;
+use crate::link::join_spec_definition::JOIN_USEROVERRIDDEN_ARGUMENT_NAME;
 use crate::link::join_spec_definition::JOIN_VERSIONS;
 use crate::link::join_spec_definition::JoinSpecDefinition;
 use crate::link::link_spec_definition::LINK_VERSIONS;
@@ -30,24 +38,26 @@ use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::merger::compose_directive_manager::ComposeDirectiveManager;
 use crate::merger::error_reporter::ErrorReporter;
+use crate::merger::field_merge_context::FieldMergeContext;
 use crate::merger::hints::HintCode;
 use crate::merger::merge_enum::EnumTypeUsage;
 use crate::schema::FederationSchema;
 use crate::schema::directive_location::DirectiveLocationExt;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
+use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
-use crate::schema::position::FieldDefinitionPosition;
-use crate::merger::field_merge_context::FieldMergeContext;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::referencer::DirectiveReferencers;
 use crate::schema::type_and_directive_specification::ArgumentMerger;
 use crate::schema::type_and_directive_specification::StaticArgumentsTransform;
+use crate::schema::validators::from_context::parse_context;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Validated;
 use crate::supergraph::CompositionHint;
 use crate::utils::human_readable::human_readable_subgraph_names;
+use apollo_compiler::name;
 
 static NON_MERGED_CORE_FEATURES: LazyLock<[Identity; 4]> = LazyLock::new(|| {
     [
@@ -774,13 +784,127 @@ impl Merger {
         }
 
         for (&idx, source) in sources.iter() {
-            if source.is_some() {
-                let join_name = self.join_spec_name(idx)?;
-                let directive = self
-                    .join_spec_definition
-                    .field_directive(&self.merged, join_name)?;
-                dest.insert_directive(&mut self.merged, Node::new(directive))?;
+            let Some(field) = source else { continue };
+
+            let subgraph_opt = self.subgraphs.get(idx);
+
+            let join_name = self.join_spec_name(idx)?;
+            let mut directive = self
+                .join_spec_definition
+                .field_directive(&self.merged, join_name)?;
+            if let Some(subgraph) = subgraph_opt {
+                if let Ok(Some(requires_name)) = subgraph.requires_directive_name() {
+                    if let Some(dir) = field.directives.get(&requires_name) {
+                        let args = subgraph
+                            .metadata()
+                            .federation_spec_definition()
+                            .requires_directive_arguments(dir)?;
+                        directive.arguments.push(Node::new(Argument {
+                            name: JOIN_REQUIRES_ARGUMENT_NAME,
+                            value: Node::new(Value::String(args.fields.to_string())),
+                        }));
+                    }
+                }
+
+                if let Ok(Some(provides_name)) = subgraph.provides_directive_name() {
+                    if let Some(dir) = field.directives.get(&provides_name) {
+                        let args = subgraph
+                            .metadata()
+                            .federation_spec_definition()
+                            .provides_directive_arguments(dir)?;
+                        directive.arguments.push(Node::new(Argument {
+                            name: JOIN_PROVIDES_ARGUMENT_NAME,
+                            value: Node::new(Value::String(args.fields.to_string())),
+                        }));
+                    }
+                }
+
+                if let Ok(Some(override_name)) = subgraph.override_directive_name() {
+                    if let Some(dir) = field.directives.get(&override_name) {
+                        let args = subgraph
+                            .metadata()
+                            .federation_spec_definition()
+                            .override_directive_arguments(dir)?;
+                        directive.arguments.push(Node::new(Argument {
+                            name: JOIN_OVERRIDE_ARGUMENT_NAME,
+                            value: Node::new(Value::String(args.from.to_string())),
+                        }));
+                        if let Some(label) = args.label {
+                            directive.arguments.push(Node::new(Argument {
+                                name: JOIN_OVERRIDE_LABEL_ARGUMENT_NAME,
+                                value: Node::new(Value::String(label.to_string())),
+                            }));
+                        }
+                    }
+                }
+
+                if !all_types_equal {
+                    directive.arguments.push(Node::new(Argument {
+                        name: JOIN_TYPE_ARGUMENT_NAME,
+                        value: Node::new(Value::String(field.ty.to_string())),
+                    }));
+                }
+
+                let field_pos: FieldDefinitionPosition = dest.clone().into();
+                if subgraph.metadata().is_field_external(&field_pos) {
+                    directive.arguments.push(Node::new(Argument {
+                        name: JOIN_EXTERNAL_ARGUMENT_NAME,
+                        value: Node::new(Value::Boolean(true)),
+                    }));
+                }
+
+                if let Ok(Some(from_context_name)) = subgraph.from_context_directive_name() {
+                    let mut ctx_args = Vec::new();
+                    for arg in &field.arguments {
+                        if let Some(fc_dir) = arg.directives.get(&from_context_name) {
+                            let fc_args = subgraph
+                                .metadata()
+                                .federation_spec_definition()
+                                .from_context_directive_arguments(fc_dir)?;
+                            if let (Some(ctx), Some(sel)) = parse_context(fc_args.field) {
+                                let ctx_name = format!("{}__{}", self.names[idx], ctx);
+                                let obj = vec![
+                                    (name!("context"), Node::new(Value::String(ctx_name))),
+                                    (
+                                        name!("name"),
+                                        Node::new(Value::String(arg.name.to_string())),
+                                    ),
+                                    (name!("type"), Node::new(Value::String(arg.ty.to_string()))),
+                                    (name!("selection"), Node::new(Value::String(sel))),
+                                ];
+                                ctx_args.push(Node::new(Value::Object(obj)));
+                            }
+                        }
+                    }
+                    if !ctx_args.is_empty() {
+                        directive.arguments.push(Node::new(Argument {
+                            name: JOIN_CONTEXTARGUMENTS_ARGUMENT_NAME,
+                            value: Node::new(Value::List(ctx_args)),
+                        }));
+                    }
+                }
+            } else if !all_types_equal {
+                // still record type when no subgraph data
+                directive.arguments.push(Node::new(Argument {
+                    name: JOIN_TYPE_ARGUMENT_NAME,
+                    value: Node::new(Value::String(field.ty.to_string())),
+                }));
             }
+
+            if merge_context.is_used_overridden(idx) {
+                directive.arguments.push(Node::new(Argument {
+                    name: JOIN_USEROVERRIDDEN_ARGUMENT_NAME,
+                    value: Node::new(Value::Boolean(true)),
+                }));
+            }
+            if let Some(label) = merge_context.override_label(idx) {
+                directive.arguments.push(Node::new(Argument {
+                    name: JOIN_OVERRIDE_LABEL_ARGUMENT_NAME,
+                    value: Node::new(Value::String(label.to_string())),
+                }));
+            }
+
+            dest.insert_directive(&mut self.merged, Node::new(directive))?;
         }
         Ok(())
     }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -12,6 +12,7 @@ use apollo_compiler::ast::DirectiveDefinition;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::schema::EnumValueDefinition;
+use apollo_compiler::schema::Component;
 use apollo_compiler::schema::FieldDefinition;
 use apollo_compiler::validation::Valid;
 use itertools::Itertools;
@@ -84,6 +85,99 @@ static BUILT_IN_DIRECTIVES: [&str; 6] = [
 
 /// Type alias for Sources mapping - maps subgraph indices to optional values
 pub(crate) type Sources<T> = IndexMap<usize, Option<T>>;
+
+/// Trait for schema elements that expose a list of applied directives.
+pub(crate) trait HasDirectives {
+    fn directive_names(&self) -> Vec<Name>;
+}
+
+impl<T: HasDirectives> HasDirectives for Node<T> {
+    fn directive_names(&self) -> Vec<Name> {
+        T::directive_names(self)
+    }
+}
+
+impl<T: HasDirectives + ?Sized> HasDirectives for Component<T> {
+    fn directive_names(&self) -> Vec<Name> {
+        T::directive_names(&**self)
+    }
+}
+
+impl<T: HasDirectives> HasDirectives for Option<T> {
+    fn directive_names(&self) -> Vec<Name> {
+        match self {
+            Some(v) => v.directive_names(),
+            None => Vec::new(),
+        }
+    }
+}
+
+impl<T: HasDirectives + ?Sized> HasDirectives for &T {
+    fn directive_names(&self) -> Vec<Name> {
+        (*self).directive_names()
+    }
+}
+
+
+impl HasDirectives for FieldDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|n| n.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for EnumValueDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|n| n.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::InputValueDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::ObjectType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::InterfaceType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::UnionType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::EnumType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::InputObjectType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::ScalarType {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+impl HasDirectives for apollo_compiler::schema::SchemaDefinition {
+    fn directive_names(&self) -> Vec<Name> {
+        self.directives.0.iter().map(|c| c.name.clone()).collect()
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct MergeResult {
@@ -756,12 +850,12 @@ impl Merger {
         todo!("Implement merge_description")
     }
 
-    fn record_applied_directives_to_merge<T: Clone>(
+    fn record_applied_directives_to_merge<T: HasDirectives + Clone>(
         &mut self,
         sources: &Sources<Option<T>>,
         _dest: &mut T,
     ) {
-        let mut names = Self::gather_applied_directive_names(sources);
+        let mut names = self.gather_applied_directive_names(sources);
 
         if let Some(inaccessible) = &self.inaccessible_directive_name_in_supergraph {
             if names.contains(inaccessible) {
@@ -778,16 +872,17 @@ impl Merger {
     }
 
     /// Collect the names of directives applied to the provided sources.
-    fn gather_applied_directive_names<T>(sources: &Sources<Option<T>>) -> HashSet<Name>
+    fn gather_applied_directive_names<T>(&self, sources: &Sources<Option<T>>) -> HashSet<Name>
     where
-        T: Clone,
+        T: HasDirectives + Clone,
     {
         let mut names = HashSet::new();
-        for source in sources.values().flatten() {
-            // Without access to the underlying schema element types here, we cannot
-            // inspect directive applications. This placeholder merely records that
-            // a source existed.
-            let _ = source; // suppress unused variable warnings
+        for (&idx, source) in sources.iter() {
+            for name in source.directive_names() {
+                if self.is_merged_directive(&self.names[idx], &Directive { name: name.clone(), arguments: vec![] }) {
+                    names.insert(name);
+                }
+            }
         }
         names
     }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use crate::bail;
 use crate::error::CompositionError;
 use crate::error::FederationError;
+use crate::error::SingleFederationError;
 use crate::internal_error;
 use crate::link::federation_spec_definition::FEDERATION_OPERATION_TYPES;
 use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
@@ -929,6 +930,7 @@ impl Merger {
         sources: Sources<Node<FieldDefinition>>,
         dest: &ObjectOrInterfaceFieldDefinitionPosition,
     ) -> Result<(), FederationError> {
+        let _without_external = self.validate_and_filter_external(&sources, dest);
         // Determine if every source that defines the field marks it @external.
         let mut every_external = true;
         for (&idx, source) in sources.iter() {
@@ -1082,6 +1084,50 @@ impl Merger {
                 }
             })
             .collect()
+    }
+
+    /// Return a copy of `sources` where any field marked `@external` in its
+    /// originating subgraph has been filtered out.  Also reports an error if
+    /// such external fields have merged directives applied to them.
+    fn validate_and_filter_external(
+        &mut self,
+        sources: &Sources<Node<FieldDefinition>>,
+        dest: &ObjectOrInterfaceFieldDefinitionPosition,
+    ) -> Sources<Node<FieldDefinition>> {
+        let mut filtered: IndexMap<usize, Option<Node<FieldDefinition>>> = IndexMap::default();
+        for (&idx, source) in sources.iter() {
+            let Some(field) = source else {
+                filtered.insert(idx, None);
+                continue;
+            };
+
+            let is_external = self
+                .subgraphs
+                .get(idx)
+                .map(|s| s.metadata().is_field_external(&dest.clone().into()))
+                .unwrap_or(false);
+
+            if !is_external {
+                filtered.insert(idx, Some(field.clone()));
+            } else {
+                filtered.insert(idx, None);
+                for directive in &field.directives {
+                    if self.is_merged_directive(&self.names[idx], directive) {
+                        self.error_reporter.add_subgraph_error(
+                            &self.names[idx],
+                            SingleFederationError::MergedDirectiveApplicationOnExternal {
+                                message: format!(
+                                    "Cannot apply merged directive {} to external field \"{}\"",
+                                    directive.name,
+                                    dest.coordinate(),
+                                ),
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        filtered
     }
 
     // TODO: These error reporting functions are not yet fully implemented

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -916,9 +916,45 @@ impl Merger {
         sources: Sources<Node<FieldDefinition>>,
         dest: &ObjectFieldDefinitionPosition,
     ) -> Result<(), FederationError> {
-        // In the future this will merge descriptions, arguments and types.
-        // For now we only attach join directives for the given sources.
-        self.add_join_field(&sources, &dest.clone().into())
+        self.merge_field(sources, &dest.clone().into())
+    }
+
+    /// Merge the given field sources into the destination field following the
+    /// JavaScript implementation. Currently this only checks for the case where
+    /// all sources are marked `@external` and attaches the corresponding join
+    /// metadata.
+    pub(crate) fn merge_field(
+        &mut self,
+        sources: Sources<Node<FieldDefinition>>,
+        dest: &ObjectOrInterfaceFieldDefinitionPosition,
+    ) -> Result<(), FederationError> {
+        // Determine if every source that defines the field marks it @external.
+        let mut every_external = true;
+        for (&idx, source) in sources.iter() {
+            if let Some(field) = source {
+                if let Some(subgraph) = self.subgraphs.get(idx) {
+                    if !subgraph.metadata().is_field_external(&dest.clone().into()) {
+                        every_external = false;
+                        break;
+                    }
+                } else {
+                    every_external = false;
+                    break;
+                }
+            } else {
+                every_external = false;
+                break;
+            }
+        }
+
+        if every_external {
+            // TODO: report EXTERNAL_MISSING_ON_BASE error once error handling is fully implemented
+            return Ok(());
+        }
+
+        // TODO: merge descriptions, directives and arguments as in the JS implementation.
+
+        self.add_join_field(&sources, dest)
     }
 
     /// Determine whether a `@join__field` directive is required for this field merge.

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -11,6 +11,7 @@ use apollo_compiler::ast::DirectiveDefinition;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::schema::EnumValueDefinition;
+use apollo_compiler::schema::FieldDefinition;
 use apollo_compiler::validation::Valid;
 use itertools::Itertools;
 
@@ -36,6 +37,8 @@ use crate::schema::directive_location::DirectiveLocationExt;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
+use crate::merger::field_merge_context::FieldMergeContext;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::referencer::DirectiveReferencers;
 use crate::schema::type_and_directive_specification::ArgumentMerger;
@@ -747,6 +750,83 @@ impl Merger {
 
     fn is_inaccessible_directive_in_supergraph(&self, _value: &EnumValueDefinition) -> bool {
         todo!("Implement is_inaccessible_directive_in_supergraph")
+    }
+
+    /// Add a `@join__field` directive for each source field present.
+    pub(crate) fn add_join_field(
+        &mut self,
+        sources: &Sources<Node<FieldDefinition>>,
+        dest: &ObjectOrInterfaceFieldDefinitionPosition,
+    ) -> Result<(), FederationError> {
+        let merge_context = FieldMergeContext::new(sources);
+        let mut iter = sources
+            .iter()
+            .filter_map(|(_, f)| f.as_ref().map(|field| &field.ty));
+        let all_types_equal = if let Some(first) = iter.next() {
+            iter.all(|ty| ty == first)
+        } else {
+            true
+        };
+
+        if !self.needs_join_field(sources, dest, all_types_equal, &merge_context) {
+            return Ok(());
+        }
+
+        for (&idx, source) in sources.iter() {
+            if source.is_some() {
+                let join_name = self.join_spec_name(idx)?;
+                let directive = self
+                    .join_spec_definition
+                    .field_directive(&self.merged, join_name)?;
+                dest.insert_directive(&mut self.merged, Node::new(directive))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Determine whether a `@join__field` directive is required for this field merge.
+    pub(crate) fn needs_join_field(
+        &self,
+        sources: &Sources<Node<FieldDefinition>>,
+        dest: &ObjectOrInterfaceFieldDefinitionPosition,
+        all_types_equal: bool,
+        merge_context: &FieldMergeContext,
+    ) -> bool {
+        if !all_types_equal {
+            return true;
+        }
+
+        if merge_context.some(|props, _| props.used_overridden || props.override_label.is_some()) {
+            return true;
+        }
+
+        let dest_coord = dest.coordinate();
+        if self
+            .fields_with_from_context
+            .object_or_interface_fields()
+            .any(|p| p.coordinate() == dest_coord)
+        {
+            return true;
+        }
+
+        for (&idx, source) in sources.iter() {
+            let overridden = merge_context.is_unused_overridden(idx);
+            if let Some(_field) = source {
+                if !overridden {
+                    // TODO: check for external/provides/requires once implemented
+                }
+            } else if let Some(subgraph) = self.subgraphs.get(idx) {
+                if subgraph
+                    .schema()
+                    .try_get_type(dest.type_name().clone())
+                    .is_some()
+                {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     // TODO: These error reporting functions are not yet fully implemented

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -125,6 +125,7 @@ pub(crate) struct Merger {
     pub(in crate::merger) schema_to_import_to_feature_url: HashMap<String, HashMap<String, Url>>,
     pub(in crate::merger) join_directive_identities: HashSet<Identity>,
     pub(in crate::merger) join_spec_definition: &'static JoinSpecDefinition,
+    pub(in crate::merger) applied_directives_to_merge: Vec<HashSet<Name>>,
 }
 
 #[allow(unused)]
@@ -181,6 +182,7 @@ impl Merger {
             join_directive_identities,
             inaccessible_directive_name_in_supergraph: todo!(),
             join_spec_definition: join_spec,
+            applied_directives_to_merge: Vec::new(),
         })
     }
 
@@ -754,16 +756,40 @@ impl Merger {
         todo!("Implement merge_description")
     }
 
-    fn record_applied_directives_to_merge<T>(
+    fn record_applied_directives_to_merge<T: Clone>(
         &mut self,
-        _sources: &Sources<Option<T>>,
+        sources: &Sources<Option<T>>,
         _dest: &mut T,
     ) {
-        todo!("Implement record_applied_directives_to_merge")
+        let mut names = Self::gather_applied_directive_names(sources);
+
+        if let Some(inaccessible) = &self.inaccessible_directive_name_in_supergraph {
+            if names.contains(inaccessible) {
+                names.remove(inaccessible);
+                // Actual merging of @inaccessible is handled elsewhere. This just records that it was seen.
+            }
+        }
+
+        self.applied_directives_to_merge.push(names);
     }
 
     fn is_inaccessible_directive_in_supergraph(&self, _value: &EnumValueDefinition) -> bool {
         todo!("Implement is_inaccessible_directive_in_supergraph")
+    }
+
+    /// Collect the names of directives applied to the provided sources.
+    fn gather_applied_directive_names<T>(sources: &Sources<Option<T>>) -> HashSet<Name>
+    where
+        T: Clone,
+    {
+        let mut names = HashSet::new();
+        for source in sources.values().flatten() {
+            // Without access to the underlying schema element types here, we cannot
+            // inspect directive applications. This placeholder merely records that
+            // a source existed.
+            let _ = source; // suppress unused variable warnings
+        }
+        names
     }
 
     /// Add a `@join__field` directive for each source field present.

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::ops::Deref;
 use std::sync::LazyLock;
 
 use apollo_compiler::Name;
@@ -1025,6 +1026,62 @@ impl Merger {
         }
 
         false
+    }
+
+    /// Given a destination field in the supergraph and a particular subgraph index,
+    /// returns any instances of that field that exist on `@interfaceObject` types
+    /// in that subgraph which implement the destination object's interfaces.
+    fn fields_in_source_if_abstracted_by_interface_object(
+        &self,
+        dest_field: &FieldDefinitionPosition,
+        source_idx: usize,
+    ) -> Vec<FieldDefinitionPosition> {
+        use crate::schema::position::CompositeTypeDefinitionPosition;
+
+        let parent_in_supergraph = dest_field.parent();
+        let schema = self.subgraphs[source_idx].schema();
+
+        let CompositeTypeDefinitionPosition::Object(parent_obj) = parent_in_supergraph else {
+            return Vec::new();
+        };
+
+        if schema.try_get_type(parent_obj.type_name.clone()).is_some() {
+            return Vec::new();
+        }
+
+        let Ok(parent_obj_node) = parent_obj.get(self.merged.schema()) else {
+            return Vec::new();
+        };
+
+        parent_obj_node
+            .implements_interfaces
+            .iter()
+            .filter_map(|itf_name| {
+                let interface_pos = InterfaceTypeDefinitionPosition {
+                    type_name: itf_name.deref().clone(),
+                };
+
+                if interface_pos
+                    .field(dest_field.field_name().clone())
+                    .try_get(self.merged.schema())
+                    .is_none()
+                {
+                    return None;
+                }
+
+                match schema.try_get_type(itf_name.deref().clone()) {
+                    Some(TypeDefinitionPosition::Object(obj)) => {
+                        let field_pos = obj.field(dest_field.field_name().clone());
+                        if field_pos.try_get(schema.schema()).is_some() {
+                            Some(field_pos.into())
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            })
+            .collect()
     }
 
     // TODO: These error reporting functions are not yet fully implemented

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -46,6 +46,7 @@ use crate::schema::directive_location::DirectiveLocationExt;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::FieldDefinitionPosition;
+use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
@@ -909,6 +910,17 @@ impl Merger {
         Ok(())
     }
 
+    /// Merge an object field and attach `@join__field` directives.
+    pub(crate) fn merge_object_field(
+        &mut self,
+        sources: Sources<Node<FieldDefinition>>,
+        dest: &ObjectFieldDefinitionPosition,
+    ) -> Result<(), FederationError> {
+        // In the future this will merge descriptions, arguments and types.
+        // For now we only attach join directives for the given sources.
+        self.add_join_field(&sources, &dest.clone().into())
+    }
+
     /// Determine whether a `@join__field` directive is required for this field merge.
     pub(crate) fn needs_join_field(
         &self,
@@ -929,11 +941,10 @@ impl Merger {
         // join directive (@external, @requires, @provides).
         for (&idx, source) in sources.iter() {
             if let Some(field) = source {
-                if !merge_context.is_unused_overridden(idx) {
-                    if let Some(subgraph) = self.subgraphs.get(idx) {
-                        let field_pos: FieldDefinitionPosition = dest.clone().into();
-                        let schema = subgraph.schema();
-                        let metadata = subgraph.metadata();
+                if let Some(subgraph) = self.subgraphs.get(idx) {
+                    let field_pos: FieldDefinitionPosition = dest.clone().into();
+                    let schema = subgraph.schema();
+                    let metadata = subgraph.metadata();
 
                         if metadata.is_field_external(&field_pos) {
                             return true;
@@ -950,7 +961,6 @@ impl Merger {
                                 return true;
                             }
                         }
-                    }
                 }
             }
         }
@@ -965,18 +975,15 @@ impl Merger {
         }
 
         for (&idx, source) in sources.iter() {
-            let overridden = merge_context.is_unused_overridden(idx);
-            if let Some(_field) = source {
-                if !overridden {
-                    // All checks handled above
-                }
-            } else if let Some(subgraph) = self.subgraphs.get(idx) {
-                if subgraph
-                    .schema()
-                    .try_get_type(dest.type_name().clone())
-                    .is_some()
-                {
-                    return true;
+            if source.is_none() {
+                if let Some(subgraph) = self.subgraphs.get(idx) {
+                    if subgraph
+                        .schema()
+                        .try_get_type(dest.type_name().clone())
+                        .is_some()
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -38,6 +38,7 @@ use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
+use crate::schema::position::FieldDefinitionPosition;
 use crate::merger::field_merge_context::FieldMergeContext;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::referencer::DirectiveReferencers;
@@ -800,6 +801,36 @@ impl Merger {
             return true;
         }
 
+        // Check if any source field has federation directives that require a
+        // join directive (@external, @requires, @provides).
+        for (&idx, source) in sources.iter() {
+            if let Some(field) = source {
+                if !merge_context.is_unused_overridden(idx) {
+                    if let Some(subgraph) = self.subgraphs.get(idx) {
+                        let field_pos: FieldDefinitionPosition = dest.clone().into();
+                        let schema = subgraph.schema();
+                        let metadata = subgraph.metadata();
+
+                        if metadata.is_field_external(&field_pos) {
+                            return true;
+                        }
+
+                        if let Ok(Some(provides_name)) = subgraph.provides_directive_name() {
+                            if field_pos.has_applied_directive(schema, &provides_name) {
+                                return true;
+                            }
+                        }
+
+                        if let Ok(Some(requires_name)) = subgraph.requires_directive_name() {
+                            if field_pos.has_applied_directive(schema, &requires_name) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         let dest_coord = dest.coordinate();
         if self
             .fields_with_from_context
@@ -813,7 +844,7 @@ impl Merger {
             let overridden = merge_context.is_unused_overridden(idx);
             if let Some(_field) = source {
                 if !overridden {
-                    // TODO: check for external/provides/requires once implemented
+                    // All checks handled above
                 }
             } else if let Some(subgraph) = self.subgraphs.get(idx) {
                 if subgraph

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -46,8 +46,8 @@ use crate::schema::directive_location::DirectiveLocationExt;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::FieldDefinitionPosition;
-use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::referencer::DirectiveReferencers;
@@ -946,21 +946,21 @@ impl Merger {
                     let schema = subgraph.schema();
                     let metadata = subgraph.metadata();
 
-                        if metadata.is_field_external(&field_pos) {
+                    if metadata.is_field_external(&field_pos) {
+                        return true;
+                    }
+
+                    if let Ok(Some(provides_name)) = subgraph.provides_directive_name() {
+                        if field_pos.has_applied_directive(schema, &provides_name) {
                             return true;
                         }
+                    }
 
-                        if let Ok(Some(provides_name)) = subgraph.provides_directive_name() {
-                            if field_pos.has_applied_directive(schema, &provides_name) {
-                                return true;
-                            }
+                    if let Ok(Some(requires_name)) = subgraph.requires_directive_name() {
+                        if field_pos.has_applied_directive(schema, &requires_name) {
+                            return true;
                         }
-
-                        if let Ok(Some(requires_name)) = subgraph.requires_directive_name() {
-                            if field_pos.has_applied_directive(schema, &requires_name) {
-                                return true;
-                            }
-                        }
+                    }
                 }
             }
         }

--- a/apollo-federation/src/merger/mod.rs
+++ b/apollo-federation/src/merger/mod.rs
@@ -5,3 +5,4 @@ mod hints;
 mod merge;
 mod merge_enum;
 mod merge_union;
+mod field_merge_context;

--- a/apollo-federation/src/merger/mod.rs
+++ b/apollo-federation/src/merger/mod.rs
@@ -1,8 +1,8 @@
 mod compose_directive_manager;
 mod error_reporter;
+mod field_merge_context;
 mod hints;
 #[path = "merger.rs"]
 mod merge;
 mod merge_enum;
 mod merge_union;
-mod field_merge_context;


### PR DESCRIPTION
## Summary
- implement `FieldMergeContext` helper
- expose `Merger::needs_join_field`
- wire new module
- ensure `add_join_field` checks if a join directive is required

## Testing
- `cargo test -p apollo-federation --lib merger::merge_enum::tests::test_add_join_field -- --nocapture`
- `cargo test -p apollo-federation --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6873b27135fc83299c8657c4795b4a8a